### PR TITLE
Fix: Pagination Options

### DIFF
--- a/src/pages/Releases/ReleasesPage.js
+++ b/src/pages/Releases/ReleasesPage.js
@@ -39,7 +39,7 @@ const ReleasesPage = props => {
     const { classes, gitHubURL } = props;
     const versions = useReleases(gitHubURL);
     const [page, setPage] = useState(0);
-    const [rowsPerPage, setRowsPerPage] = useState(4);
+    const [rowsPerPage, setRowsPerPage] = useState(5);
 
     function getMarkdownText(body) {
         const rawMarkup = marked(DOMPurify.sanitize(body));
@@ -106,7 +106,7 @@ const ReleasesPage = props => {
                         <TableFooter>
                             <TableRow>
                                 <TablePagination
-                                    rowsPerPageOptions={[rowsPerPage, 10, 25]}
+                                    rowsPerPageOptions={[5, 10, 25]}
                                     count={versions.length}
                                     onChangePage={handlePageChange}
                                     onChangeRowsPerPage={


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[] Documentation update
[x] Bug fix
[] New functionality
[] Changes an existing functionality
[] Other, please explain:

**What changes did you make? (Give an overview)**
Default number in the rows per page was 4 because I wanted to make sure pagination was visible in the scrollable area. However the other page options of 10 and 25 really don't go well with a default option of 4. So I made the default number as 5 and so other options 10 and 25 looks related. Also because I was using the same state variable `rowsPerPage` for the page options as I was doing it for the TablePagination, an error was seen when rows per page option is flipped. With these changes that error is no longer produced.

**Add any screenshots**
![image](https://user-images.githubusercontent.com/19715972/64360421-1987fb00-cfd0-11e9-9d45-48fae2aee015.png)

