### PR TITLE
New: Use ETAG in header for reading releases from the cache

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -43,7 +43,7 @@ export default {
         }),
     VERSIONS_PATH: "versions",
     LOCAL_STORAGE: {
-        GET_RELEASES_ETAG: "GET_RELEASES_ETAG",
-        RELEASES_DATA: "RELEASES_DATA",
+        GET_RELEASES_ETAG: "getReleasesETAG",
+        RELEASES_DATA: "releasesData",
     }
 };

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -41,5 +41,9 @@ export default {
                 ].join(",")
             }
         }),
-    VERSIONS_PATH: "versions"
+    VERSIONS_PATH: "versions",
+    LOCAL_STORAGE: {
+        GET_RELEASES_ETAG: "GET_RELEASES_ETAG",
+        RELEASES_DATA: "RELEASES_DATA",
+    }
 };

--- a/src/helpers/releasesInfo.js
+++ b/src/helpers/releasesInfo.js
@@ -9,17 +9,29 @@ export const retrieveReleases = gitHubURL =>
                 constants.GITHUB_API_RELEASE_URL.replace(
                     "{repo_name}",
                     repositoryName
-                )
+                ),
+                {
+                    headers: {
+                        "If-None-Match": localStorage.getItem(constants.LOCAL_STORAGE.GET_RELEASES_ETAG) || ""
+                    }
+                }
             )
             .then(response => {
                 if (response.status === 200) {
+                    localStorage.setItem(constants.LOCAL_STORAGE.GET_RELEASES_ETAG, response.headers.etag.toString());
+                    localStorage.setItem(constants.LOCAL_STORAGE.RELEASES_DATA, JSON.stringify(response.data));
                     resolve(response.data);
                 } else {
                     resolve([]);
                 }
             })
             .catch(err => {
-                reject(err);
+                if (err.response && err.response.status === 304) {
+                    resolve(JSON.parse(localStorage.getItem(constants.LOCAL_STORAGE.RELEASES_DATA)));
+                }
+                else {
+                    reject(err);
+                }
             });
     });
 
@@ -31,4 +43,4 @@ export const getLatestRelease = releases => {
 };
 
 export const isLatestRelease = (versions, targetRelease) =>
-           getLatestRelease(versions) === targetRelease.tag_name;
+    getLatestRelease(versions) === targetRelease.tag_name;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[] Documentation update
[] Bug fix
[x] New functionality
[] Changes an existing functionality
[] Other, please explain:

**What changes did you make? (Give an overview)**
An HTTP call to retrieve the releases does not use any authentication, as a result of this there is a rate limit of how much requests can be made. To solve a problem, I decided to capture the ETAG from the first retrieve releases request that is returned with a status of 200. The response of this request is cached in a `localStorage`. And then use this ETAG in the subsequent requests for retrieving releases. If the resource (releases data) has not changed then the github API server will return with 304-status and no response. In this situation we will return the cached version of data. 

**Add any screenshots**
`localStorage` used for storing releases data and ETAG 

![image](https://user-images.githubusercontent.com/19715972/64737038-94aa4f00-d4b1-11e9-9f50-01af0b8cc15d.png)

I refreshed the page and you  can see `releases` returned with 304
![image](https://user-images.githubusercontent.com/19715972/64737107-bb688580-d4b1-11e9-967f-0d958abbbbaf.png)

When clicked the versions chip then also `releases` returned with 304 because resource is not changed 
![image](https://user-images.githubusercontent.com/19715972/64737185-e357e900-d4b1-11e9-98c8-4ed83801eb78.png)

