### PR TITLE
Fix: Added expiration date on local storage

### DIFF
--- a/src/helpers/releasesInfo.js
+++ b/src/helpers/releasesInfo.js
@@ -4,6 +4,17 @@ import constants from "./constants";
 export const retrieveReleases = gitHubURL =>
     new Promise((resolve, reject) => {
         const repositoryName = gitHubURL.split("github.com")[1];
+        const lsReleasesData = localStorage.getItem(constants.LOCAL_STORAGE.RELEASES_DATA) || "";
+        const releasesData = lsReleasesData.split(";")[0];
+        const lsReleasesTimeStampEntry = lsReleasesData.split(";")[1] || "";
+
+        // Only retrieve releases if timeStamp is within 24hrs
+        // Return from localStorage if retrieving release the same day; else make an API call
+        if(new Date() < new Date(lsReleasesTimeStampEntry) ) {
+            resolve(JSON.parse(releasesData));
+            return;
+        }
+
         axios
             .get(
                 constants.GITHUB_API_RELEASE_URL.replace(
@@ -18,18 +29,22 @@ export const retrieveReleases = gitHubURL =>
             )
             .then(response => {
                 if (response.status === 200) {
+                    // Set a expiry date as 24hrs from the creation on the local storage item.
+                    const expiryDate = new Date(new Date().getTime() + (24 * 60 * 60 * 1000));
                     localStorage.setItem(constants.LOCAL_STORAGE.GET_RELEASES_ETAG, response.headers.etag.toString());
-                    localStorage.setItem(constants.LOCAL_STORAGE.RELEASES_DATA, JSON.stringify(response.data));
+                    localStorage.setItem(constants.LOCAL_STORAGE.RELEASES_DATA, `${JSON.stringify(response.data)};${expiryDate}`);
                     resolve(response.data);
                 } else {
+                    localStorage.removeItem(constants.LOCAL_STORAGE.RELEASES_DATA);
                     resolve([]);
                 }
             })
             .catch(err => {
                 if (err.response && err.response.status === 304) {
-                    resolve(JSON.parse(localStorage.getItem(constants.LOCAL_STORAGE.RELEASES_DATA)));
+                    resolve(JSON.parse(releasesData));
                 }
                 else {
+                    localStorage.removeItem(constants.LOCAL_STORAGE.RELEASES_DATA);
                     reject(err);
                 }
             });

--- a/src/hooks/useReleases.js
+++ b/src/hooks/useReleases.js
@@ -4,7 +4,7 @@ import {retrieveReleases} from "../helpers/releasesInfo";
 const useReleases = (gitHubURL) => {
     const [releases, setReleases] = useState([]);
     useEffect(() => {
-        // Make a request to get releases
+        // Retrieve releases only if none present in localStorage
         if (!releases.length) {
             retrieveReleases(gitHubURL).then((response) => {
                 setReleases(response);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (Check any that's applicable)**

-   [ ] Feature
-   [x] Bug fix
-   [ ] Dependency updates
-   [ ] Documentation updates
-   [ ] Build related changes
-   [ ] Changes an existing functionality
-   [ ] Other, please explain:

**Does this introduce a breaking change?**

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**What changes did you make? (Give an overview)**
Releases were retrieved even when tabs were flipped. This caused a lot of screen flickering and unnecessary calls to API to get releases. I added a expiry date of 24 hrs on the local storage item. If the releases are present in the local storage then they will be read. Otherwise the API call will be made - resulting in either 200 or 304 status depending on whether the resource has changed.

**Add any screenshots**