### PR TITLE
Update: Use ReleasesURLProvider to solve gitHubURL prop drilling issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,48 +15,51 @@ import {
     NotFoundPage,
     ReleasesPage
 } from "./pages";
+import {
+    ReleasesURLProvider
+} from "./providers/releases/ReleasesURLProvider";
 
 function AppRouter(props) {
     const { pages, startLink, gitHubURL } = props;
     return (
         <ThemeProvider theme={constants.THEME()}>
-            <HashRouter basename={process.env.PUBLIC_URL}>
-                <main>
-                    <Switch>
-                        {flatten(pages, constants.PATHNAME_PROPERTY).map(p => (
+            <ReleasesURLProvider gitHubURL={gitHubURL}>
+                <HashRouter basename={process.env.PUBLIC_URL}>
+                    <main>
+                        <Switch>
+                            {flatten(pages, constants.PATHNAME_PROPERTY).map(p => (
+                                <Route
+                                    exact
+                                    key={p}
+                                    path={p}
+                                    render={() => (
+                                        <GettingStartedPage
+                                            pages={pages}
+                                        />
+                                    )}
+                                />
+                            ))}
                             <Route
                                 exact
-                                key={p}
-                                path={p}
+                                path="/"
                                 render={() => (
-                                    <GettingStartedPage
-                                        pages={pages}
-                                        gitHubURL={gitHubURL}
+                                    <HomePage
+                                        startLink={startLink}
                                     />
                                 )}
                             />
-                        ))}
-                        <Route
-                            exact
-                            path="/"
-                            render={() => (
-                                <HomePage
-                                    startLink={startLink}
-                                    gitHubURL={gitHubURL}
-                                />
-                            )}
-                        />
-                        <Route
-                            exact
-                            path={`/${constants.VERSIONS_PATH}`}
-                            render={() => (
-                                <ReleasesPage gitHubURL={gitHubURL} />
-                            )}
-                        />
-                        <Route component={NotFoundPage} />
-                    </Switch>
-                </main>
-            </HashRouter>
+                            <Route
+                                exact
+                                path={`/${constants.VERSIONS_PATH}`}
+                                render={() => (
+                                    <ReleasesPage/>
+                                )}
+                            />
+                            <Route component={NotFoundPage}/>
+                        </Switch>
+                    </main>
+                </HashRouter>
+            </ReleasesURLProvider>
         </ThemeProvider>
     );
 }

--- a/src/components/Drawer/ResponsiveDrawer.js
+++ b/src/components/Drawer/ResponsiveDrawer.js
@@ -119,7 +119,7 @@ class ResponsiveDrawer extends React.Component {
 
     render() {
         const { props, state } = this;
-        const { classes, pages, currentPage, gitHubURL } = props;
+        const { classes, pages, currentPage } = props;
         const { mobileOpen } = state;
         const drawer = (
             <RouterContextConsumer>
@@ -149,7 +149,6 @@ class ResponsiveDrawer extends React.Component {
                 <Header
                     onMenuClick={this.handleDrawerToggle}
                     pages={pages}
-                    gitHubURL={gitHubURL}
                 />
                 <nav className={classes.drawer}>
                     <Hidden smUp implementation="css">
@@ -194,8 +193,7 @@ class ResponsiveDrawer extends React.Component {
 ResponsiveDrawer.propTypes = {
     classes: PropTypes.objectOf(PropTypes.string).isRequired,
     pages: PropTypes.arrayOf(PropTypes.object).isRequired,
-    currentPage: PropTypes.objectOf(PropTypes.string).isRequired,
-    gitHubURL: PropTypes.string.isRequired
+    currentPage: PropTypes.objectOf(PropTypes.string).isRequired
 };
 
 export default withStyles(styles, { withTheme: true })(ResponsiveDrawer);

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -11,6 +11,7 @@ import constants from "../../helpers/constants";
 import SearchBar from "../Search/SearchBar";
 import GithubIcon from "../SvgIcons/GitHubIcon";
 import LatestReleasePage from "../../pages/Releases/LatestReleasePage";
+import {useReleasesURL} from "../../providers/releases/ReleasesURLProvider";
 
 const styles = theme => ({
     appBarHome: {
@@ -45,7 +46,8 @@ const styles = theme => ({
 });
 
 function Header(props) {
-    const { classes, onMenuClick, isHome, pages, gitHubURL, withNav } = props;
+    const { classes, onMenuClick, isHome, pages, withNav } = props;
+    const [gitHubURL] = useReleasesURL();
     return (
         <AppBar
             position="fixed"
@@ -73,7 +75,6 @@ function Header(props) {
                 <LatestReleasePage
                     className={classes.appBarRelease}
                     isHome={isHome}
-                    gitHubURL={gitHubURL}
                 />
                 <Tooltip
                     className={classes.appBarRelease}
@@ -103,7 +104,6 @@ Header.propTypes = {
     pages: PropTypes.arrayOf(PropTypes.object),
     onMenuClick: PropTypes.func,
     isHome: PropTypes.bool,
-    gitHubURL: PropTypes.string,
     withNav: PropTypes.bool
 };
 
@@ -111,8 +111,7 @@ Header.defaultProps = {
     pages: [],
     onMenuClick: () => {},
     isHome: false,
-    withNav: true,
-    gitHubURL: ""
+    withNav: true
 };
 
 export default withStyles(styles, { withTheme: true })(Header);

--- a/src/helpers/propTypesHelper.js
+++ b/src/helpers/propTypesHelper.js
@@ -1,0 +1,6 @@
+import PropTypes from "prop-types";
+
+export const childrenPropType = PropTypes.oneOfType([ // eslint-disable-line import/prefer-default-export
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+]);

--- a/src/pages/GettingStarted/GettingStartedPage.js
+++ b/src/pages/GettingStarted/GettingStartedPage.js
@@ -5,13 +5,12 @@ import { RouterContextProvider } from "../../components/Context/RouterContext";
 import ResponsiveDrawer from "../../components/Drawer/ResponsiveDrawer";
 
 function GettingStartedPage(props) {
-    const { pages, location, gitHubURL } = props;
+    const { pages, location } = props;
     return (
         <RouterContextProvider value={location}>
             <ResponsiveDrawer
                 pages={pages}
                 currentPage={location}
-                gitHubURL={gitHubURL}
             />
         </RouterContextProvider>
     );
@@ -19,8 +18,7 @@ function GettingStartedPage(props) {
 
 GettingStartedPage.propTypes = {
     pages: PropTypes.arrayOf(PropTypes.object).isRequired,
-    location: PropTypes.objectOf(PropTypes.string).isRequired,
-    gitHubURL: PropTypes.string.isRequired
+    location: PropTypes.objectOf(PropTypes.string).isRequired
 };
 
 export default withRouter(GettingStartedPage);

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -4,18 +4,17 @@ import HomePageBlurb from "../../components/Content/HomePageBlurb";
 import Header from "../../components/Header/Header";
 
 function HomePage(props) {
-    const { startLink, gitHubURL } = props;
+    const { startLink } = props;
     return (
         <>
-            <Header isHome gitHubURL={gitHubURL} />
+            <Header isHome/>
             <HomePageBlurb startLink={startLink} />
         </>
     );
 }
 
 HomePage.propTypes = {
-    startLink: PropTypes.string.isRequired,
-    gitHubURL: PropTypes.string.isRequired
+    startLink: PropTypes.string.isRequired
 };
 
 export default HomePage;

--- a/src/pages/Releases/LatestReleasePage.js
+++ b/src/pages/Releases/LatestReleasePage.js
@@ -6,6 +6,7 @@ import Box from "@material-ui/core/Box";
 import useReleases from "../../hooks/useReleases";
 import constants from "../../helpers/constants";
 import { getLatestRelease } from "../../helpers/releasesInfo";
+import { useReleasesURL } from "../../providers/releases/ReleasesURLProvider";
 
 const styles = theme => ({
     container: {
@@ -15,13 +16,14 @@ const styles = theme => ({
     }
 });
 const LatestReleasePage = props => {
-    const { className, classes, gitHubURL, isHome } = props;
+    const { className, classes, isHome } = props;
+    const [gitHubURL] = useReleasesURL();
+    const releases = useReleases(gitHubURL);
 
     if (isHome || !gitHubURL) {
         return "";
     }
 
-    const releases = useReleases(gitHubURL);
     return releases.length ? (
         <Box className={className}>
             <Chip
@@ -40,14 +42,12 @@ const LatestReleasePage = props => {
 LatestReleasePage.propTypes = {
     classes: PropTypes.objectOf(PropTypes.string).isRequired,
     className: PropTypes.string,
-    isHome: PropTypes.bool,
-    gitHubURL: PropTypes.string
+    isHome: PropTypes.bool
 };
 
 LatestReleasePage.defaultProps = {
     className: "",
-    isHome: false,
-    gitHubURL: ""
+    isHome: false
 };
 
 export default withStyles(styles, { withTheme: true })(LatestReleasePage);

--- a/src/pages/Releases/ReleasesPage.js
+++ b/src/pages/Releases/ReleasesPage.js
@@ -17,6 +17,7 @@ import CardContent from "@material-ui/core/CardContent";
 import useReleases from "../../hooks/useReleases";
 import Header from "../../components/Header/Header";
 import { isLatestRelease } from "../../helpers/releasesInfo";
+import { useReleasesURL } from "../../providers/releases/ReleasesURLProvider";
 
 const styles = theme => ({
     container: {
@@ -35,7 +36,8 @@ const styles = theme => ({
 });
 
 const ReleasesPage = props => {
-    const { classes, gitHubURL } = props;
+    const { classes } = props;
+    const [gitHubURL] = useReleasesURL();
     const versions = useReleases(gitHubURL);
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(5);
@@ -67,7 +69,7 @@ const ReleasesPage = props => {
 
     return (
         <Paper>
-            <Header withNav={false} gitHubURL={gitHubURL} />
+            <Header withNav={false}/>
             <>
                 <Table className={classes.container}>
                     <TableBody>
@@ -118,7 +120,6 @@ const ReleasesPage = props => {
 };
 
 ReleasesPage.propTypes = {
-    gitHubURL: PropTypes.string.isRequired,
     classes: PropTypes.objectOf(PropTypes.string).isRequired
 };
 

--- a/src/providers/releases/ReleasesURLProvider.js
+++ b/src/providers/releases/ReleasesURLProvider.js
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from "react";
+import PropTypes from "prop-types";
+import { childrenPropType } from "../../helpers/propTypesHelper";
+
+const ReleasesURLContext = createContext();
+
+const useReleasesURL = () => {
+    const context = useContext(ReleasesURLContext);
+    if (context === undefined) {
+        throw new Error("useReleasesURL must be used within ReleasesURLProvider");
+    }
+    return context;
+};
+
+const ReleasesURLProvider = ({ children, gitHubURL }) => {
+    const [url, setURL] = useState(gitHubURL);
+    const value = React.useMemo(() => [url, setURL], [url]);
+    return (
+        <ReleasesURLContext.Provider value={value}>
+            {children}
+        </ReleasesURLContext.Provider>
+    );
+};
+
+ReleasesURLProvider.propTypes = {
+    children: childrenPropType.isRequired,
+    gitHubURL: PropTypes.string
+};
+
+ReleasesURLProvider.defaultProps = {
+  gitHubURL: ""
+};
+
+export { ReleasesURLProvider, useReleasesURL };
+


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**What is the purpose of this pull request? (Check any that's applicable)**

-   [ ] Feature
-   [ ] Bug fix
-   [ ] Dependency updates
-   [ ] Documentation updates
-   [ ] Build related changes
-   [ ] Changes an existing functionality
-   [x] Other, please explain:
`gitHubURL` prop was drilled down upto level 4 and twice. To solve this issue a `ReleasesURLProvider` is created that provides the `releasesURL` value to whoever needs it.

**Does this introduce a breaking change?**

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**What changes did you make? (Give an overview)**

**Add any screenshots**: N/A